### PR TITLE
Add HUD scene

### DIFF
--- a/src/entities/Brick.js
+++ b/src/entities/Brick.js
@@ -2,13 +2,18 @@ export class Brick extends Phaser.GameObjects.Rectangle {
   constructor(scene, x, y, width, height, color, alpha) {
     super(scene, x, y, width, height, color, alpha);
 
-    scene.add.existing(this);
-    scene.physics.add.existing(this);
+    this.scene = scene;
+    this.scene.add.existing(this);
+    this.scene.physics.add.existing(this);
+
     this.body.immovable = true;
     this.body.setCollideWorldBounds(true);
 
     this.toches = 0;
     this.maxToches = Phaser.Math.Between(1, 4);
+    this.points = Phaser.Math.Between(5, 20);
+
+    console.log(this.scene);
   }
 
   hit() {
@@ -24,6 +29,8 @@ export class Brick extends Phaser.GameObjects.Rectangle {
     }
 
     if (this.toches === this.maxToches) {
+      this.scene.update_points(this.points);
+
       this.destroy();
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { Game } from "./scenes/Game";
 import { GameOver } from "./scenes/GameOver";
 import { MainMenu } from "./scenes/MainMenu";
 import { Preloader } from "./scenes/Preloader";
+import { Hud } from "./scenes/Hud";
 
 //  Find out more information about the Game Config at:
 //  https://newdocs.phaser.io/docs/3.70.0/Phaser.Types.Core.GameConfig
@@ -23,7 +24,7 @@ const config = {
       debug: false,
     },
   },
-  scene: [Boot, Preloader, MainMenu, Game, GameOver],
+  scene: [Boot, Preloader, MainMenu, Game, GameOver, Hud],
 };
 
 export default new Phaser.Game(config);

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -15,10 +15,10 @@ export class Game extends Scene {
   game_over_timeout;
   timer_event;
 
-  init() {
+  init(data) {
     // Reset points
-    this.points = 0;
-    this.game_over_timeout = 99;
+    this.points = data.points || 0;
+    this.game_over_timeout = data.game_over_timeout || 99;
 
     // launch the HUD scene
     this.scene.launch("Hud", { remaining_time: this.game_over_timeout });

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -13,14 +13,30 @@ export class Game extends Scene {
 
   points;
   game_over_timeout;
+  timer_event;
 
   init() {
     // Reset points
     this.points = 0;
-    this.game_over_timeout = 20;
+    this.game_over_timeout = 99;
 
     // launch the HUD scene
     this.scene.launch("Hud", { remaining_time: this.game_over_timeout });
+
+    // create a timmer event
+    this.timmer_event = this.time.addEvent({
+      delay: 1000,
+      callback: () => {
+        this.game_over_timeout--;
+        this.scene.get("Hud").update_timeout(this.game_over_timeout);
+
+        if (this.game_over_timeout === 0) {
+          this.scene.stop("Hud");
+          this.scene.start("GameOver");
+        }
+      },
+      loop: true,
+    });
   }
 
   create() {

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -26,6 +26,7 @@ export class Game extends Scene {
     // create a timmer event
     this.timmer_event = this.time.addEvent({
       delay: 1000,
+      loop: true,
       callback: () => {
         this.game_over_timeout--;
         this.scene.get("Hud").update_timeout(this.game_over_timeout);
@@ -35,7 +36,6 @@ export class Game extends Scene {
           this.scene.start("GameOver");
         }
       },
-      loop: true,
     });
   }
 

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -11,6 +11,9 @@ export class Game extends Scene {
     super("Game");
   }
 
+  points;
+  game_over_timeout;
+
   init() {
     // Reset points
     this.points = 0;
@@ -46,6 +49,7 @@ export class Game extends Scene {
       console.log("worldbounds");
       if (down) {
         console.log("hit bottom");
+        this.scene.stop("Hud");
         this.scene.start("GameOver");
       }
     });
@@ -53,5 +57,10 @@ export class Game extends Scene {
 
   update() {
     this.paddle.update();
+  }
+
+  update_points(points) {
+    this.points += points;
+    this.scene.get("Hud").update_points(this.points);
   }
 }

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -11,6 +11,15 @@ export class Game extends Scene {
     super("Game");
   }
 
+  init() {
+    // Reset points
+    this.points = 0;
+    this.game_over_timeout = 20;
+
+    // launch the HUD scene
+    this.scene.launch("Hud", { remaining_time: this.game_over_timeout });
+  }
+
   create() {
     // instanciar una nueva paleta.
     // crea un nuevo objeto

--- a/src/scenes/Hud.js
+++ b/src/scenes/Hud.js
@@ -18,22 +18,20 @@ export class Hud extends Scene {
   }
 
   create() {
-    this.points_text = this.add.bitmapText(
+    this.points_text = this.add.text(10, 10, "POINTS:0000", {
+      fontSize: "24px",
+      color: "#ffffff",
+    });
+
+    this.remaining_time_text = this.add.text(
+      this.scale.width - 200,
       10,
-      10,
-      "pixelfont",
-      "POINTS:0000",
-      24
+      `REMAINING:${this.remaining_time.toString().padStart(2, "0")}s`,
+      {
+        fontSize: "24px",
+        color: "#ffffff",
+      }
     );
-    this.remaining_time_text = this.add
-      .bitmapText(
-        this.scale.width - 10,
-        10,
-        "pixelfont",
-        `REMAINING:${this.remaining_time}s`,
-        24
-      )
-      .setOrigin(1, 0);
   }
 
   update_points(points) {

--- a/src/scenes/Hud.js
+++ b/src/scenes/Hud.js
@@ -1,0 +1,48 @@
+import { Scene } from "phaser";
+
+// The HUD scene is the scene that shows the points and the remaining time.
+export class Hud extends Scene {
+  remaining_time = 0;
+
+  remaining_time_text;
+  points_text;
+
+  constructor() {
+    super("Hud");
+  }
+
+  init(data) {
+    // fadeIn([duration], [red], [green], [blue], [callback], [context])
+    this.cameras.main.fadeIn(1000, 0, 0, 0);
+    this.remaining_time = data.remaining_time;
+  }
+
+  create() {
+    this.points_text = this.add.bitmapText(
+      10,
+      10,
+      "pixelfont",
+      "POINTS:0000",
+      24
+    );
+    this.remaining_time_text = this.add
+      .bitmapText(
+        this.scale.width - 10,
+        10,
+        "pixelfont",
+        `REMAINING:${this.remaining_time}s`,
+        24
+      )
+      .setOrigin(1, 0);
+  }
+
+  update_points(points) {
+    this.points_text.setText(`POINTS:${points.toString().padStart(4, "0")}`);
+  }
+
+  update_timeout(timeout) {
+    this.remaining_time_text.setText(
+      `REMAINING:${timeout.toString().padStart(2, "0")}s`
+    );
+  }
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8321a2c2-c090-4495-b4ec-2e6ce4e57d5e)

Se agrego una escena para menu superior con testos de puntos y tiempo restante.
La escena tiene dos metodos: update_points y update_timeout.

Se agrega, en la creacion de ladrillos, la asignacion de puntos ramdomizados entre 5 y 20.